### PR TITLE
Fix S3 storage disks with empt region

### DIFF
--- a/src/Database/migrations/2023_09_04_102400_fix_s3_empty_region.php
+++ b/src/Database/migrations/2023_09_04_102400_fix_s3_empty_region.php
@@ -1,0 +1,37 @@
+<?php
+
+use Biigle\Modules\UserDisks\UserDisk;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        UserDisk::where('type', 's3')
+            ->eachById(function ($disk) {
+                $options = $disk->options;
+                if (array_key_exists('region', $options) && is_null($options['region'])) {
+                    unset($options['region']);
+                    $disk->options = $options;
+                    $disk->save();
+                }
+            });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+};

--- a/src/Http/Requests/StoreUserDisk.php
+++ b/src/Http/Requests/StoreUserDisk.php
@@ -49,6 +49,7 @@ class StoreUserDisk extends FormRequest
     {
         $optionKeys = array_keys($this->getTypeValidationRules());
         $options = $this->safe()->only($optionKeys);
+        $options = array_filter($options, fn ($v) => !is_null($v));
 
         return $options;
     }

--- a/src/config/user_disks.php
+++ b/src/config/user_disks.php
@@ -25,8 +25,9 @@ return [
             ],
             'throw' => true,
             'bucket_endpoint' => true,
-            // The region may or may not be required.
-            'region' => '',
+            // The region may or may not be provided. However, the S3 SDK requires at
+            // least a placeholder.
+            'region' => 'us-east-1',
             // These should be configured by the user.
             'bucket' => '',
             'key' => '',

--- a/tests/Http/Controllers/Api/UserDiskControllerTest.php
+++ b/tests/Http/Controllers/Api/UserDiskControllerTest.php
@@ -84,7 +84,7 @@ class UserDiskControllerTest extends ApiTestCase
             ->assertStatus(201);
 
         $disk = UserDisk::where('user_id', $this->user()->id)->first();
-        $this->assertEquals('', $disk->options['region']);
+        $this->assertArrayNotHasKey('region', $disk->options);
     }
 
     public function testStoreAruna()

--- a/tests/UserDiskTest.php
+++ b/tests/UserDiskTest.php
@@ -117,7 +117,7 @@ class UserDiskTest extends ModelTestCase
             'throw' => true,
             'read-only' => true,
             'bucket_endpoint' => true,
-            'region' => '',
+            'region' => 'us-east-1',
         ];
 
         $this->assertEquals($expect, $disk->getConfig());


### PR DESCRIPTION
In a newer version of the S3 SDK, the region must be filled even it it is not used.