### PR TITLE
Fix WebDAV URIs with path components

### DIFF
--- a/src/Http/Requests/StoreUserDisk.php
+++ b/src/Http/Requests/StoreUserDisk.php
@@ -4,6 +4,7 @@ namespace Biigle\Modules\UserDisks\Http\Requests;
 
 use Biigle\Modules\UserDisks\UserDisk;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Uri;
 use Illuminate\Validation\Rule;
 
 class StoreUserDisk extends FormRequest
@@ -71,5 +72,23 @@ class StoreUserDisk extends FormRequest
                 $validator->errors()->add('name', 'Disk name already exists');
             }
         });
+    }
+
+    /**
+     * Prepare the data for validation.
+     */
+    protected function prepareForValidation(): void
+    {
+        if ($this->input('type') === 'webdav' && $this->has('baseUri')) {
+            $uri = Uri::of($this->input('baseUri'));
+            $path = $uri->path();
+            if ($path && $path !== '/') {
+                $this->merge([
+                    'baseUri' => (string) $uri->withPath(''),
+                    'pathPrefix' => $path,
+                ]);
+            }
+
+        }
     }
 }

--- a/src/config/user_disks.php
+++ b/src/config/user_disks.php
@@ -81,6 +81,7 @@ return [
             'baseUri' => 'required|url',
             'userName' => 'required_with:password',
             'password' => 'required_with:userName',
+            'pathPrefix' => 'filled',
         ],
 
         'elements' => [
@@ -113,6 +114,7 @@ return [
             'baseUri' => 'filled|url',
             'userName' => 'required_with:password',
             'password' => 'required_with:userName',
+            'pathPrefix' => 'filled',
         ],
 
         'elements' => [

--- a/src/resources/views/store/webdav.blade.php
+++ b/src/resources/views/store/webdav.blade.php
@@ -1,7 +1,7 @@
 <div class="col-xs-12">
     <div class="form-group @error('baseUri') has-error @enderror">
         <label>Base URI</label>
-        <input type="url" name="baseUri" required class="form-control" value="{{old('baseUri')}}" placeholder="https://example.com/webdav">
+        <input type="url" name="baseUri" required class="form-control" value="{{old('baseUri').old('pathPrefix')}}" placeholder="https://example.com/webdav">
         @error('baseUri')
             <p class="help-block">{{$message}}</p>
         @else

--- a/src/resources/views/update/webdav.blade.php
+++ b/src/resources/views/update/webdav.blade.php
@@ -1,7 +1,7 @@
 <div class="col-xs-12">
     <div class="form-group @error('baseUri') has-error @enderror">
         <label>Base URI</label>
-        <input type="url" name="baseUri" required class="form-control" value="{{old('baseUri', $disk->options['baseUri'])}}" placeholder="https://example.com/webdav">
+        <input type="url" name="baseUri" required class="form-control" value="{{old('baseUri', $disk->options['baseUri']).old('pathPrefix', $disk->options['pathPrefix'] ?? '')}}" placeholder="https://example.com/webdav">
         @error('baseUri')
             <p class="help-block">{{$message}}</p>
         @enderror


### PR DESCRIPTION
The URIs are now automatically split before validation so the adapter configuration is correct.

Closes #30 