### PR TITLE
Update dCache URL

### DIFF
--- a/src/config/user_disks.php
+++ b/src/config/user_disks.php
@@ -42,7 +42,7 @@ return [
 
         'dcache' => [
             'driver' => 'dcache',
-            'baseUri' => 'https://hifis-storage-ht.desy.de:2880',
+            'baseUri' => 'https://hifis-storage.desy.de',
             'pathPrefix' => '',
         ],
 


### PR DESCRIPTION
Change back from hifis-storage-ht but use the recommended port 443. The hifis-storage-ht backend responds with redirects that remove a macaroon from the request, which results in unauthenticated follow-up range requests for videos.

References https://github.com/biigle/user-disks/pull/47