### PR TITLE
Implement dCache token exchange using JWT authorization grant

### DIFF
--- a/src/Http/Controllers/Api/UserDiskController.php
+++ b/src/Http/Controllers/Api/UserDiskController.php
@@ -111,22 +111,45 @@ class UserDiskController extends Controller
                 ->with('message', 'There was an error while obtaining the user attributes.');
         }
 
-        $postData = [
-            'client_id' => config('user_disks.dcache-token-exchange.client_id'),
-            'client_secret' => config('user_disks.dcache-token-exchange.client_secret'),
-            'grant_type' => 'urn:ietf:params:oauth:grant-type:token-exchange',
-            'subject_token_type' => 'urn:ietf:params:oauth:token-type:access_token',
-            'subject_token' => $user->token,
-            'subject_issuer' => 'oidc',
-            'audience' => 'token-exchange',
-            // Setting the scope here is critical, otherwise the scope will be reset
-            // to the default scope after token refresh (and the token will no longer
-            // work for dCache).
-            'scope' => 'entitlements groups openid token-exchange profile email',
-        ];
-
+        // Step 1: Exchange the HAAI token for one addressed to dCache Keycloak.
+        // The audience claim in the resulting token must match the Keycloak
+        // realm so Keycloak accepts it in the JWT Authorization Grant (step 2).
         try {
-            $response = Http::asForm()->post(UserDisk::DCACHE_TOKEN_ENDPOINT, $postData);
+            $url = config('user_disks.dcache-token-exchange.helmholtz_token_endpoint');
+            $helmholtzResponse = Http::asForm()->post($url, [
+                'grant_type' => 'urn:ietf:params:oauth:grant-type:token-exchange',
+                'subject_token' => $user->token,
+                'subject_token_type' => 'urn:ietf:params:oauth:token-type:access_token',
+                'requested_token_type' => 'urn:ietf:params:oauth:token-type:access_token',
+                'audience' => config('user_disks.dcache-token-exchange.keycloak_audience'),
+                'scope' => 'openid profile email token-exchange',
+                'client_id' => config('services.haai.client_id'),
+                'client_secret' => config('services.haai.client_secret'),
+            ])->throw();
+        } catch (Exception $e) {
+            Log::error('There was an error during the HAAI token exchange.', ['exception' => $e]);
+
+            return $redirectResponse
+                ->with('messageType', 'danger')
+                ->with('message', 'There was an error during the HAAI token exchange.');
+        }
+
+        $intermediateToken = $helmholtzResponse->json()['access_token'];
+
+        // Step 2: JWT Authorization Grant: present the Keycloak-addressed token to
+        // Keycloak to obtain the final dCache access and refresh tokens.
+        try {
+            $url = config('user_disks.dcache-token-exchange.token_endpoint');
+            $response = Http::asForm()->post($url, [
+                'grant_type' => 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                'assertion' => $intermediateToken,
+                'client_id' => config('user_disks.dcache-token-exchange.client_id'),
+                'client_secret' => config('user_disks.dcache-token-exchange.client_secret'),
+                // Setting the scope here is critical, otherwise the scope will be reset
+                // to the default scope after token refresh (and the token will no longer
+                // work for dCache).
+                'scope' => 'openid profile email',
+            ])->throw();
         } catch (Exception $e) {
             Log::error('There was an error while obtaining a dCache token.', ['exception' => $e]);
 

--- a/src/UserDisk.php
+++ b/src/UserDisk.php
@@ -15,11 +15,6 @@ class UserDisk extends Model
     use HasFactory;
 
     /**
-     * Endpoint URL for dCache token exchange and refresh.
-     */
-    const DCACHE_TOKEN_ENDPOINT = "https://keycloak.desy.de/auth/realms/production/protocol/openid-connect/token";
-
-    /**
      * Map of type key to type name/description.
      */
     const TYPES = [
@@ -202,7 +197,7 @@ class UserDisk extends Model
         ];
 
         try {
-            $response = Http::asForm()->post(static::DCACHE_TOKEN_ENDPOINT, $postData);
+            $response = Http::asForm()->post(config('user_disks.dcache-token-exchange.token_endpoint'), $postData);
         } catch (Exception $e) {
             return false;
         }

--- a/src/config/user_disks.php
+++ b/src/config/user_disks.php
@@ -163,11 +163,16 @@ return [
     ],
 
     /*
-     | OIDC credentials for the token exchange with the dCache Keycloak.
+     | Credentials and endpoints for the dCache JWT Authorization Grant flow.
      */
     'dcache-token-exchange' => [
-       'client_id' => env('DCACHE_TOKEN_EXCHANGE_CLIENT_ID'),
-       'client_secret' => env('DCACHE_TOKEN_EXCHANGE_CLIENT_SECRET'),
+        'helmholtz_token_endpoint' => env('DCACHE_HELMHOLTZ_TOKEN_ENDPOINT', 'https://login.helmholtz.de/oauth2/token'),
+        'token_endpoint' => env('DCACHE_TOKEN_ENDPOINT', 'https://keycloak.desy.de/auth/realms/production/protocol/openid-connect/token'),
+        // Keycloak realm URL used as the audience claim in the intermediate Helmholtz token.
+        'keycloak_audience' => env('DCACHE_KEYCLOAK_AUDIENCE', 'https://keycloak.desy.de/auth/realms/production'),
+        // Keycloak client credentials for the JWT Authorization Grant.
+        'client_id' => env('DCACHE_TOKEN_EXCHANGE_CLIENT_ID'),
+        'client_secret' => env('DCACHE_TOKEN_EXCHANGE_CLIENT_SECRET'),
     ],
 
     /*

--- a/tests/Http/Controllers/Api/UserDiskControllerTest.php
+++ b/tests/Http/Controllers/Api/UserDiskControllerTest.php
@@ -1505,6 +1505,8 @@ class UserDiskControllerTest extends ApiTestCase
             'user_disks.types' => ['dcache'],
             'user_disks.dcache-token-exchange.client_id' => 'test-client-id',
             'user_disks.dcache-token-exchange.client_secret' => 'test-client-secret',
+            'services.haai.client_id' => 'haai-client-id',
+            'services.haai.client_secret' => 'haai-client-secret',
         ]);
 
         $this->beUser();
@@ -1522,7 +1524,10 @@ class UserDiskControllerTest extends ApiTestCase
             ->andReturn($socialiteProvider);
 
         Http::fake([
-            UserDisk::DCACHE_TOKEN_ENDPOINT => Http::response([
+            'login.helmholtz.de/*' => Http::response([
+                'access_token' => 'intermediate-token',
+            ], 200),
+            'keycloak.desy.de/*' => Http::response([
                 'access_token' => 'dcache-access-token',
                 'refresh_token' => 'dcache-refresh-token',
                 'expires_in' => 3600,
@@ -1583,12 +1588,14 @@ class UserDiskControllerTest extends ApiTestCase
         $this->assertNull($disk);
     }
 
-    public function testStoreDCacheErrorDuringTokenExchange()
+    public function testStoreDCacheErrorDuringHaaiExchange()
     {
         config([
             'user_disks.types' => ['dcache'],
             'user_disks.dcache-token-exchange.client_id' => 'test-client-id',
             'user_disks.dcache-token-exchange.client_secret' => 'test-client-secret',
+            'services.haai.client_id' => 'haai-client-id',
+            'services.haai.client_secret' => 'haai-client-secret',
         ]);
 
         $this->beUser();
@@ -1606,14 +1613,15 @@ class UserDiskControllerTest extends ApiTestCase
 
         Log::shouldReceive('error')->once();
 
-        Http::shouldReceive('asForm')->andReturnSelf();
-        Http::shouldReceive('post')->andThrow(new Exception);
+        Http::fake([
+            'login.helmholtz.de/*' => Http::response(['error' => 'server_error'], 500),
+        ]);
 
         $response = $this->get('/user-disks/dcache/callback');
 
         $response->assertRedirect(route('create-storage-disks'));
         $response->assertSessionHas('messageType', 'danger');
-        $response->assertSessionHas('message', 'There was an error while obtaining a dCache token.');
+        $response->assertSessionHas('message', 'There was an error during the HAAI token exchange.');
 
         $disk = UserDisk::where('user_id', $this->user()->id)->first();
         $this->assertNull($disk);
@@ -1653,6 +1661,8 @@ class UserDiskControllerTest extends ApiTestCase
             'user_disks.types' => ['dcache'],
             'user_disks.dcache-token-exchange.client_id' => 'test-client-id',
             'user_disks.dcache-token-exchange.client_secret' => 'test-client-secret',
+            'services.haai.client_id' => 'haai-client-id',
+            'services.haai.client_secret' => 'haai-client-secret',
         ]);
 
         $disk = UserDisk::factory()->create([
@@ -1682,7 +1692,10 @@ class UserDiskControllerTest extends ApiTestCase
             ->andReturn($socialiteProvider);
 
         Http::fake([
-            UserDisk::DCACHE_TOKEN_ENDPOINT => Http::response([
+            'login.helmholtz.de/*' => Http::response([
+                'access_token' => 'intermediate-token',
+            ], 200),
+            'keycloak.desy.de/*' => Http::response([
                 'access_token' => 'new-access-token',
                 'refresh_token' => 'new-refresh-token',
                 'expires_in' => 3600,
@@ -1749,12 +1762,14 @@ class UserDiskControllerTest extends ApiTestCase
         $this->assertEquals('old_refresh_token', $disk->options['refresh_token']);
     }
 
-    public function testUpdateDCacheWithExpiredRefreshTokenErrorDuringTokenExchange()
+    public function testUpdateDCacheWithExpiredRefreshTokenErrorDuringHaaiExchange()
     {
         config([
             'user_disks.types' => ['dcache'],
             'user_disks.dcache-token-exchange.client_id' => 'test-client-id',
             'user_disks.dcache-token-exchange.client_secret' => 'test-client-secret',
+            'services.haai.client_id' => 'haai-client-id',
+            'services.haai.client_secret' => 'haai-client-secret',
         ]);
 
         $disk = UserDisk::factory()->create([
@@ -1784,8 +1799,102 @@ class UserDiskControllerTest extends ApiTestCase
 
         Log::shouldReceive('error')->once();
 
-        Http::shouldReceive('asForm')->andReturnSelf();
-        Http::shouldReceive('post')->andThrow(new Exception);
+        Http::fake([
+            'login.helmholtz.de/*' => Http::response(['error' => 'server_error'], 500),
+        ]);
+
+        session(['dcache-disk-id' => $disk->id]);
+        $response = $this->get('/user-disks/dcache/callback');
+
+        $response->assertRedirect(route('update-storage-disks', $disk->id));
+        $response->assertSessionHas('messageType', 'danger');
+        $response->assertSessionHas('message', 'There was an error during the HAAI token exchange.');
+
+        $disk->refresh();
+        $this->assertEquals('old_access_token', $disk->options['token']);
+        $this->assertEquals('old_refresh_token', $disk->options['refresh_token']);
+    }
+
+    public function testStoreDCacheErrorDuringJwtGrant()
+    {
+        config([
+            'user_disks.types' => ['dcache'],
+            'user_disks.dcache-token-exchange.client_id' => 'test-client-id',
+            'user_disks.dcache-token-exchange.client_secret' => 'test-client-secret',
+            'services.haai.client_id' => 'haai-client-id',
+            'services.haai.client_secret' => 'haai-client-secret',
+        ]);
+
+        $this->beUser();
+
+        $socialiteUser = (object) ['token' => 'oidc-access-token'];
+
+        $socialiteProvider = Mockery::mock(Provider::class);
+        $socialiteProvider->shouldReceive('redirectUrl')->andReturnSelf();
+        $socialiteProvider->shouldReceive('setScopes')->andReturnSelf();
+        $socialiteProvider->shouldReceive('user')->andReturn($socialiteUser);
+
+        Socialite::shouldReceive('driver')
+            ->with('haai')
+            ->andReturn($socialiteProvider);
+
+        Log::shouldReceive('error')->once();
+
+        Http::fake([
+            'login.helmholtz.de/*' => Http::response(['access_token' => 'intermediate-token'], 200),
+            'keycloak.desy.de/*' => Http::response(['error' => 'server_error'], 500),
+        ]);
+
+        $response = $this->get('/user-disks/dcache/callback');
+
+        $response->assertRedirect(route('create-storage-disks'));
+        $response->assertSessionHas('messageType', 'danger');
+        $response->assertSessionHas('message', 'There was an error while obtaining a dCache token.');
+
+        $disk = UserDisk::where('user_id', $this->user()->id)->first();
+        $this->assertNull($disk);
+    }
+
+    public function testUpdateDCacheWithExpiredRefreshTokenErrorDuringJwtGrant()
+    {
+        config([
+            'user_disks.types' => ['dcache'],
+            'user_disks.dcache-token-exchange.client_id' => 'test-client-id',
+            'user_disks.dcache-token-exchange.client_secret' => 'test-client-secret',
+            'services.haai.client_id' => 'haai-client-id',
+            'services.haai.client_secret' => 'haai-client-secret',
+        ]);
+
+        $disk = UserDisk::factory()->create([
+            'type' => 'dcache',
+            'name' => 'my dcache',
+            'options' => [
+                'token' => 'old_access_token',
+                'refresh_token' => 'old_refresh_token',
+                'token_expires_at' => now()->addMinutes(30),
+                'refresh_token_expires_at' => now()->addHour(),
+            ],
+        ]);
+
+        $this->be($disk->user);
+
+        $socialiteUser = (object) ['token' => 'oidc-access-token'];
+
+        $socialiteProvider = Mockery::mock(Provider::class);
+        $socialiteProvider->shouldReceive('redirectUrl')->andReturnSelf();
+        $socialiteProvider->shouldReceive('setScopes')->andReturnSelf();
+        $socialiteProvider->shouldReceive('user')->andReturn($socialiteUser);
+
+        Socialite::shouldReceive('driver')
+            ->with('haai')
+            ->andReturn($socialiteProvider);
+
+        Log::shouldReceive('error')->once();
+
+        Http::fake([
+            'login.helmholtz.de/*' => Http::response(['access_token' => 'intermediate-token'], 200),
+            'keycloak.desy.de/*' => Http::response(['error' => 'server_error'], 500),
+        ]);
 
         session(['dcache-disk-id' => $disk->id]);
         $response = $this->get('/user-disks/dcache/callback');

--- a/tests/UserDiskTest.php
+++ b/tests/UserDiskTest.php
@@ -331,8 +331,8 @@ class UserDiskTest extends ModelTestCase
     public function testRefreshDCacheToken()
     {
         config([
-            'services.dcache-token-exchange.client_id' => 'test-client-id',
-            'services.dcache-token-exchange.client_secret' => 'test-client-secret',
+            'user_disks.dcache-token-exchange.client_id' => 'test-client-id',
+            'user_disks.dcache-token-exchange.client_secret' => 'test-client-secret',
         ]);
 
         Http::fake([
@@ -365,8 +365,8 @@ class UserDiskTest extends ModelTestCase
     public function testRefreshDCacheTokenHttpError()
     {
         config([
-            'services.dcache-token-exchange.client_id' => 'test-client-id',
-            'services.dcache-token-exchange.client_secret' => 'test-client-secret',
+            'user_disks.dcache-token-exchange.client_id' => 'test-client-id',
+            'user_disks.dcache-token-exchange.client_secret' => 'test-client-secret',
         ]);
 
         Http::fake([


### PR DESCRIPTION
This updates the dCache token exchange to use JWT Authorization Grant, as the old method is no longer supported in newer Keycloak versions.